### PR TITLE
Add a base module for configuring a VPC

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+      - feature/jrb/bootstrap
+  pull_request:
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    container: hashicorp/terraform:latest
+    env:
+      DOCKER_BUILDKIT: 1
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Bash
+        run: apk add --no-cache bash
+
+      - name: Execute cibuild
+        run: ./scripts/cibuild

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+*tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,114 @@
+# terraform-aws-vpc [![CI](https://github.com/d3b-center/terraform-aws-vpc/workflows/CI/badge.svg?branch=master)](https://github.com/d3b-center/terraform-aws-vpc/actions?query=workflow%3ACI)
+
+A Terraform module to create a dual-stack (IPv4/IPv6) Amazon Web Services (AWS) Virtual Private Cloud (VPC).
+
+- [Usage](#usage)
+  - [Connecting to the Bastion with Session Manager](#connecting-to-the-bastion-with-aws-session-manager)
+  - [Configuring Security Group Rules](#configuring-security-group-rules)
+- [Variables](#variables)
+- [Outputs](#outputs)
+
+## Usage
+
+This module creates a VPC alongside a variety of related resources, including:
+
+- Public and private subnets.
+- Public and private route tables.
+- Elastic IPs.
+- Network interfaces.
+- NAT gateways.
+- An internet gateway and an egress-only internet gateway (for private IPv6 traffic).
+- An S3 VPC endpoint.
+- VPC endpoints to support AWS Session Manager.
+- A bastion EC2 instance.
+
+Example usage:
+
+```hcl
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm*"]
+  }
+}
+
+module "vpc" {}
+  source = "github.com/d3b-center/terraform-aws-vpc"
+
+  name                               = "Default"
+  region                             = "us-east-1"
+  cidr_block                         = "10.0.0.0/16"
+  private_subnet_cidr_blocks         = ["10.0.1.0/24", "10.0.3.0/24"]
+  private_subnet_ipv6_prefix_indices = [1, 3]
+  public_subnet_cidr_blocks          = ["10.0.0.0/24", "10.0.2.0/24"]
+  public_subnet_ipv6_prefix_indices  = [0, 2]
+  availability_zones                 = ["us-east-1a", "us-east-1b"]
+  bastion_ami                        = data.aws_ami.amazon_linux.id
+  bastion_instance_type              = "t3.nano"
+
+  tags = {}
+}
+```
+
+See the [examples](./examples/) directory for a complete implementation.
+
+### Connecting to the Bastion with Session Manager
+
+After copying the bastion instance ID from the AWS Console, you can start a session:
+
+```console
+$ aws ssm start-session --target i-0471c64f8747dadae
+
+Starting session with SessionId: iamuser-0f4532b020626b7be
+sh-4.2$
+```
+
+For information about accessing other VPC resources, see [How can I use an SSH tunnel through AWS Systems Manager to access my private VPC resources?](https://aws.amazon.com/premiumsupport/knowledge-center/systems-manager-ssh-vpc-resources/)
+
+### Configuring Security Group Rules
+
+Aside from those needed to support Session Manager, this module adds no security group rules to the bastion instance, meaning that all traffic will be blocked.
+
+In order to configure security rules for the bastion, use the `bastion_security_group_id` output. For example:
+
+```hcl
+resource "aws_security_group_rule" "bastion_https_egress" {
+  type             = "egress"
+  from_port        = 443
+  to_port          = 443
+  protocol         = "tcp"
+  cidr_blocks      = ["0.0.0.0/0"]
+  ipv6_cidr_blocks = ["::/0"]
+
+  security_group_id = module.vpc.bastion_security_group_id
+}
+```
+
+## Variables
+
+- `name` - A name for the VPC (default: `Default`).
+- `region` - A valid AWS region to house VPC resources.
+- `cidr_block` - The CIDR range for the entire VPC (default: `10.0.0.0/16`).
+- `public_subnet_cidr_blocks` - A list of CIDR ranges for public subnets (default: `["10.0.0.0/24", "10.0.2.0/24"]`).
+- `public_subnet_ipv6_prefix_indices` - A list of indices corresponding to IPv6 prefixes for public subnets (default: `[0, 2]`).
+- `private_subnet_cidr_blocks` - A list of CIDR ranges for private subnets (default: `["10.0.1.0/24", "10.0.3.0/24"]`).
+- `private_subnet_ipv6_prefix_indices` - A list of indices corresponding to IPv6 prefixes for public subnets (default: `[1, 3]`).
+- `availability_zones` - A list of availability zones for subnet placement (default: `["us-east-1a", "us-east-1b"]`).
+- `bastion_ami` - An AMI ID for the bastion.
+- `bastion_instance_type` - An instance type for the bastion (default: `t3.nano`).
+- `aws_ssm_managed_instance_core_policy_arn` - ARN to the canned AmazonSSMManagedInstanceCore policy. (default: `arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore`).
+- `tags` - A mapping of keys and values to apply as tags to all resources that support them (default: `{}`).
+
+## Outputs
+
+- `id` - ID of the VPC.
+- `public_subnet_ids` - A list of VPC public subnet IDs.
+- `private_subnets_ids` - A list of VPC private subnet IDs.
+- `vpc_endpoint_security_group_id` - Security group associated with the interface VPC endpoints for adding rules.
+- `bastion_security_group_id` - Security group associated with the bastion for adding rules.
+- `cidr_block` - The CIDR range for the entire VPC.
+- `ipv6_cidr_block` - The IPv6 CIDR range for the entire VPC.
+- `nat_gateway_ips` - Public IP addresses of the VPC NAT gateways.

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ resource "aws_security_group_rule" "bastion_https_egress" {
 - `private_subnets_ids` - A list of VPC private subnet IDs.
 - `vpc_endpoint_security_group_id` - Security group associated with the interface VPC endpoints for adding rules.
 - `bastion_security_group_id` - Security group associated with the bastion for adding rules.
+- `bastion_iam_role_name` - IAM role associated with the bastion for attaching IAM policies.
 - `cidr_block` - The CIDR range for the entire VPC.
 - `ipv6_cidr_block` - The IPv6 CIDR range for the entire VPC.
 - `nat_gateway_ips` - Public IP addresses of the VPC NAT gateways.

--- a/examples/README.md
+++ b/examples/README.md
@@ -49,7 +49,7 @@ region = "us-east-1"
 Next, launch an instance of the included Terraform container image:
 
 ```console
-export AWS_PROFILE=d3b-sandbox
+export AWS_PROFILE=sandbox
 docker-compose run --rm terraform
 bash-5.1#
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,61 @@
+# Example Project
+
+This directory contains an example project demonstrating usage of our VPC module, including:
+
+* Provider-level tagging using [`default_tags`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/resource-tagging#propagating-tags-to-all-resources).
+* A security group rule that allows the bastion instance to make HTTPS requests.
+* Changing the default working directory and shell for AWS Systems Manager to `~` and `/bin/bash`.
+
+- [Overview](#overview)
+- [Getting Started](#getting-started)
+  - [Dependencies](#dependencies)
+  - [Instructions](#instructions)
+
+## Overview
+
+The `terraform` directory contains a Terraform project.
+
+The `scripts` directory contains one script:
+- `infra` is a wrapper for the `terraform` command that also manages initialization.
+
+## Getting Started
+
+### Dependencies
+
+- AWS CLI 2.4+
+- Docker 20.10+
+- Docker Compose 2.2+
+
+### Instructions
+
+First, copy the following file, renaming it to `terraform-aws-vpc.tfvars` in the process:
+
+```console
+cp terraform/terraform-aws-vpc.tfvars.example terraform/terraform-aws-vpc.tfvars
+```
+
+Then, customize its contents with a text editor:
+
+- For project, use your name in title case.
+
+Here's an example of a customized `terraform-aws-vpc.tfvars`:
+
+```hcl
+project = "JohnAmazon"
+environment = "Staging"
+region = "us-east-1"
+```
+
+Next, launch an instance of the included Terraform container image:
+
+```console
+export AWS_PROFILE=d3b-sandbox
+docker-compose run --rm terraform
+bash-5.1#
+```
+
+Once inside the context of the container image, use `infra` to generate a Terraform plan:
+
+```console
+bash-5.1# ./scripts/infra plan
+```

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  terraform:
+    image: ghcr.io/d3b-center/terraform:1.1.6
+    volumes:
+      - ../:/usr/local/src
+      - $HOME/.aws:/.aws:ro
+    environment:
+      - AWS_PROFILE
+      - TERRAFORM_AWS_VPC_DEBUG=1
+    working_dir: /usr/local/src/examples
+    entrypoint: bash

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: ghcr.io/d3b-center/terraform:1.1.6
     volumes:
       - ../:/usr/local/src
-      - $HOME/.aws:/.aws:ro
+      - $HOME/.aws:/.aws
     environment:
       - AWS_PROFILE
       - TERRAFORM_AWS_VPC_DEBUG=1

--- a/examples/scripts/infra
+++ b/examples/scripts/infra
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${TERRAFORM_AWS_VPC_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+        "Usage: $(basename "$0") COMMAND OPTION[S]
+Execute Terraform subcommands.
+"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    if [[ "${1:-}" == "--help" ]]; then
+        usage
+    else
+        TERRAFORM_DIR="$(dirname "$0")/../terraform"
+
+        pushd "${TERRAFORM_DIR}"
+
+        case "${1}" in
+        plan)
+            # Clear stale modules, then re-initialize.
+            rm -rf .terraform
+            terraform init
+
+            terraform plan \
+                -var-file="terraform-aws-vpc.tfvars" \
+                -out="terraform-aws-vpc.tfplan"
+            ;;
+        apply)
+            terraform apply "terraform-aws-vpc.tfplan"
+            ;;
+        destroy)
+            terraform destroy \
+                -var-file="terraform-aws-vpc.tfvars" \
+                -auto-approve
+            ;;
+        *)
+            echo "ERROR: I don't have support for that Terraform subcommand!"
+            exit 1
+            ;;
+        esac
+
+        popd
+    fi
+fi

--- a/examples/terraform/.terraform.lock.hcl
+++ b/examples/terraform/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.2.0"
+  constraints = "~> 4.2.0"
+  hashes = [
+    "h1:qfnMtwFbsVJWvzxUCajm4zUkjEH9GDdT3FFYffEEhYQ=",
+    "zh:297d6462055eac8eb5c6735bd1a0fec23574e27d56c4c14a39efd8f3931ce4ed",
+    "zh:457319839adca3638fd76f49fd65e15756717f97ac99bd1805a1c9387a62a250",
+    "zh:57377384fa28abc4211a0916fc0fb590af238d096ad0490434ffeb89f568df9b",
+    "zh:578e1d21bd6d38bdaef0909b30959b884e84e6c464796a50e516822955db162a",
+    "zh:5e7ff13cc976f609aee4ada3c1967ba1f0ce5d276f3102a0aeaedc586d25ea80",
+    "zh:5e94f09fe1874a2365bd566fecab8f676cd720da1c0bf70875392679549ebf20",
+    "zh:93da14d7ffb8550b161cb79fe2cfc0f66848dd5022974399ae2bf88da7b9e9c5",
+    "zh:c51e4541f3d29627974dcb7f5919012a762391accb574ade9e28bdb3c92bada5",
+    "zh:eff58c1680e3f29e514919346d937bbe47278434ae03ed62443c77e878e267b1",
+    "zh:f2b749e6c6b77b26e643bbecc829977270cfefab106d5ea57e5a83e96d49cbdd",
+    "zh:fcc17e60e55c278535c332469727cf215eaea9ec81d38e2b5f05be127ee39a5b",
+  ]
+}

--- a/examples/terraform/config.tf
+++ b/examples/terraform/config.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Project     = var.project
+      Environment = var.environment
+    }
+  }
+}

--- a/examples/terraform/firewall.tf
+++ b/examples/terraform/firewall.tf
@@ -1,0 +1,13 @@
+#
+# Bastion security group resources
+#
+resource "aws_security_group_rule" "bastion_https_egress" {
+  type             = "egress"
+  from_port        = 443
+  to_port          = 443
+  protocol         = "tcp"
+  cidr_blocks      = ["0.0.0.0/0"]
+  ipv6_cidr_blocks = ["::/0"]
+
+  security_group_id = module.vpc.bastion_security_group_id
+}

--- a/examples/terraform/network.tf
+++ b/examples/terraform/network.tf
@@ -1,0 +1,36 @@
+#
+# VPC resources
+#
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm*"]
+  }
+}
+
+module "vpc" {
+  source = "../../"
+
+  name        = join("", ["vpc", var.environment, var.project])
+  region      = var.region
+  bastion_ami = data.aws_ami.amazon_linux.id
+}
+
+resource "aws_ssm_document" "default" {
+  name          = "SSM-SessionManagerRunShell"
+  document_type = "Session"
+
+  content = jsonencode({
+    schemaVersion = "1.0"
+    description   = "Document to hold regional settings for Session Manager"
+    sessionType   = "Standard_Stream"
+    inputs = {
+      shellProfile = {
+        linux = "cd ~ && /usr/bin/env bash"
+      }
+    }
+  })
+}

--- a/examples/terraform/terraform-aws-vpc.tfvars.example
+++ b/examples/terraform/terraform-aws-vpc.tfvars.example
@@ -1,0 +1,3 @@
+project = "Example"
+environment = "Staging"
+region = "us-east-1"

--- a/examples/terraform/variables.tf
+++ b/examples/terraform/variables.tf
@@ -1,0 +1,15 @@
+variable "project" {
+  type        = string
+  description = "A project namespace for the infrastructure."
+}
+
+variable "environment" {
+  type        = string
+  description = "An environment namespace for the infrastructure."
+}
+
+variable "region" {
+  type        = string
+  default     = "us-east-1"
+  description = "A valid AWS region to configure the underlying AWS SDK."
+}

--- a/examples/terraform/versions.tf
+++ b/examples/terraform/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.1.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.2.0"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,361 @@
+#
+# VPC resources
+#
+resource "aws_vpc" "default" {
+  cidr_block                       = var.cidr_block
+  enable_dns_support               = true
+  enable_dns_hostnames             = true
+  assign_generated_ipv6_cidr_block = true
+
+  tags = merge(
+    {
+      Name = var.name
+    },
+    var.tags
+  )
+}
+
+resource "aws_internet_gateway" "default" {
+  vpc_id = aws_vpc.default.id
+
+  tags = merge(
+    {
+      Name = "gwInternet"
+    },
+    var.tags
+  )
+}
+
+resource "aws_egress_only_internet_gateway" "default" {
+  vpc_id = aws_vpc.default.id
+
+  tags = merge(
+    {
+      Name = "gwInternetEgressOnly"
+    },
+    var.tags
+  )
+}
+
+resource "aws_route_table" "private" {
+  count = length(var.private_subnet_cidr_blocks)
+
+  vpc_id = aws_vpc.default.id
+
+  tags = merge(
+    {
+      Name = "PrivateRouteTable"
+    },
+    var.tags
+  )
+}
+
+resource "aws_route" "private" {
+  count = length(var.private_subnet_cidr_blocks)
+
+  route_table_id         = aws_route_table.private[count.index].id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.default[count.index].id
+}
+
+
+resource "aws_route" "ipv6_private" {
+  count = length(var.private_subnet_cidr_blocks)
+
+  route_table_id              = aws_route_table.private[count.index].id
+  destination_ipv6_cidr_block = "::/0"
+  egress_only_gateway_id      = aws_egress_only_internet_gateway.default.id
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.default.id
+
+  tags = merge(
+    {
+      Name = "PublicRouteTable"
+    },
+    var.tags
+  )
+}
+
+resource "aws_route" "public" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.default.id
+}
+
+resource "aws_route" "ipv6_public" {
+  route_table_id              = aws_route_table.public.id
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = aws_internet_gateway.default.id
+}
+
+resource "aws_subnet" "private" {
+  count = length(var.private_subnet_cidr_blocks)
+
+  vpc_id                                         = aws_vpc.default.id
+  assign_ipv6_address_on_creation                = true
+  cidr_block                                     = var.private_subnet_cidr_blocks[count.index]
+  enable_dns64                                   = true
+  enable_resource_name_dns_aaaa_record_on_launch = true
+  enable_resource_name_dns_a_record_on_launch    = true
+  ipv6_cidr_block                                = cidrsubnet(aws_vpc.default.ipv6_cidr_block, 8, var.private_subnet_ipv6_prefix_indices[count.index])
+  availability_zone                              = var.availability_zones[count.index]
+  private_dns_hostname_type_on_launch            = "resource-name"
+
+  tags = merge(
+    {
+      Name = "PrivateSubnet"
+    },
+    var.tags
+  )
+}
+
+resource "aws_subnet" "public" {
+  count = length(var.public_subnet_cidr_blocks)
+
+  vpc_id                                         = aws_vpc.default.id
+  assign_ipv6_address_on_creation                = true
+  cidr_block                                     = var.public_subnet_cidr_blocks[count.index]
+  enable_dns64                                   = true
+  enable_resource_name_dns_aaaa_record_on_launch = true
+  enable_resource_name_dns_a_record_on_launch    = true
+  ipv6_cidr_block                                = cidrsubnet(aws_vpc.default.ipv6_cidr_block, 8, var.public_subnet_ipv6_prefix_indices[count.index])
+  availability_zone                              = var.availability_zones[count.index]
+  map_public_ip_on_launch                        = true
+  private_dns_hostname_type_on_launch            = "resource-name"
+
+  tags = merge(
+    {
+      Name = "PublicSubnet"
+    },
+    var.tags
+  )
+}
+
+resource "aws_route_table_association" "private" {
+  count = length(var.private_subnet_cidr_blocks)
+
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private[count.index].id
+}
+
+resource "aws_route_table_association" "public" {
+  count = length(var.public_subnet_cidr_blocks)
+
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id       = aws_vpc.default.id
+  service_name = "com.amazonaws.${var.region}.s3"
+
+  route_table_ids = flatten([
+    aws_route_table.public.id,
+    aws_route_table.private.*.id
+  ])
+
+  tags = merge(
+    {
+      Name = "endpointS3"
+    },
+    var.tags
+  )
+}
+
+#
+# Interface VPC endpoint resources
+#
+resource "aws_security_group" "vpc_endpoint" {
+  name_prefix = "sgVpcEndpoint"
+  vpc_id      = aws_vpc.default.id
+
+  tags = merge(
+    {
+      Name = "sgVpcEndpoint"
+    },
+    var.tags
+  )
+}
+
+resource "aws_vpc_endpoint" "ec2messages" {
+  vpc_id            = aws_vpc.default.id
+  service_name      = "com.amazonaws.${var.region}.ec2messages"
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids = [
+    aws_security_group.vpc_endpoint.id
+  ]
+
+  subnet_ids          = aws_subnet.private.*.id
+  private_dns_enabled = true
+
+  tags = merge(
+    {
+      Name = "endpointEc2Messages"
+    },
+    var.tags
+  )
+}
+
+resource "aws_vpc_endpoint" "ssm" {
+  vpc_id            = aws_vpc.default.id
+  service_name      = "com.amazonaws.${var.region}.ssm"
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids = [
+    aws_security_group.vpc_endpoint.id
+  ]
+
+  subnet_ids          = aws_subnet.private.*.id
+  private_dns_enabled = true
+
+  tags = merge(
+    {
+      Name = "endpointSsm"
+    },
+    var.tags
+  )
+}
+
+resource "aws_vpc_endpoint" "ssmmessages" {
+  vpc_id            = aws_vpc.default.id
+  service_name      = "com.amazonaws.${var.region}.ssmmessages"
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids = [
+    aws_security_group.vpc_endpoint.id
+  ]
+
+  subnet_ids          = aws_subnet.private.*.id
+  private_dns_enabled = true
+
+  tags = merge(
+    {
+      Name = "endpointSsmMessages"
+    },
+    var.tags
+  )
+}
+
+#
+# NAT resources
+#
+resource "aws_eip" "nat" {
+  count = length(var.public_subnet_cidr_blocks)
+
+  vpc = true
+
+  tags = merge(
+    {
+      Name = "ElasticIP"
+    },
+    var.tags
+  )
+}
+
+resource "aws_nat_gateway" "default" {
+  depends_on = [aws_internet_gateway.default]
+
+  count = length(var.public_subnet_cidr_blocks)
+
+  allocation_id = aws_eip.nat[count.index].id
+  subnet_id     = aws_subnet.public[count.index].id
+
+  tags = merge(
+    {
+      Name = "gwNAT"
+    },
+    var.tags
+  )
+}
+
+#
+# Bastion resources
+#
+resource "aws_security_group" "bastion" {
+  name_prefix = "sgBastion"
+  vpc_id      = aws_vpc.default.id
+
+  tags = merge(
+    {
+      Name = "sgBastion"
+    },
+    var.tags
+  )
+}
+
+resource "aws_security_group_rule" "bastion_vpc_endpoint_egress" {
+  type      = "egress"
+  from_port = 443
+  to_port   = 443
+  protocol  = "tcp"
+
+  security_group_id        = aws_security_group.bastion.id
+  source_security_group_id = aws_security_group.vpc_endpoint.id
+
+  description = "Allow outbound TCP traffic to the interface VPC endpoints on 443."
+}
+
+resource "aws_security_group_rule" "vpc_endpoint_bastion_ingress" {
+  type      = "ingress"
+  from_port = 443
+  to_port   = 443
+  protocol  = "tcp"
+
+  security_group_id        = aws_security_group.vpc_endpoint.id
+  source_security_group_id = aws_security_group.bastion.id
+
+  description = "Allow inbound TCP traffic from the bastion on 443."
+}
+
+data "aws_iam_policy_document" "ec2_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "bastion" {
+  name_prefix        = "BastionRole"
+  assume_role_policy = data.aws_iam_policy_document.ec2_assume_role.json
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "ssm_managed_instance_core" {
+  role       = aws_iam_role.bastion.name
+  policy_arn = var.aws_ssm_managed_instance_core_policy_arn
+}
+
+resource "aws_iam_instance_profile" "bastion" {
+  name_prefix = "BastionInstanceProfile"
+  role        = aws_iam_role.bastion.name
+
+  tags = var.tags
+}
+
+resource "aws_instance" "bastion" {
+  ami                    = var.bastion_ami
+  availability_zone      = var.availability_zones[0]
+  ebs_optimized          = true
+  iam_instance_profile   = aws_iam_instance_profile.bastion.id
+  instance_type          = var.bastion_instance_type
+  monitoring             = true
+  subnet_id              = aws_subnet.private[0].id
+  vpc_security_group_ids = [aws_security_group.bastion.id]
+
+  tags = merge(
+    {
+      Name = "Bastion"
+    },
+    var.tags
+  )
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,39 @@
+output "id" {
+  value       = aws_vpc.default.id
+  description = "ID of the VPC."
+}
+
+output "public_subnet_ids" {
+  value       = aws_subnet.public.*.id
+  description = "A list of VPC public subnet IDs."
+}
+
+output "private_subnet_ids" {
+  value       = aws_subnet.private.*.id
+  description = "A list of VPC private subnet IDs."
+}
+
+output "vpc_endpoint_security_group_id" {
+  value       = aws_security_group.vpc_endpoint.id
+  description = "Security group associated with the interface VPC endpoints for adding rules."
+}
+
+output "bastion_security_group_id" {
+  value       = aws_security_group.bastion.id
+  description = "Security group associated with the bastion for adding rules."
+}
+
+output "cidr_block" {
+  value       = var.cidr_block
+  description = "The CIDR range for the entire VPC."
+}
+
+output "ipv6_cidr_block" {
+  value       = aws_vpc.default.ipv6_cidr_block
+  description = "The IPv6 CIDR range for the entire VPC."
+}
+
+output "nat_gateway_ips" {
+  value       = [aws_eip.nat.*.public_ip]
+  description = "Public IP addresses of the VPC NAT gateways."
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,6 +23,11 @@ output "bastion_security_group_id" {
   description = "Security group associated with the bastion for adding rules."
 }
 
+output "bastion_iam_role_name" {
+  value       = aws_iam_role.bastion.name
+  description = "IAM role associated with the bastion for attaching IAM policies."
+}
+
 output "cidr_block" {
   value       = var.cidr_block
   description = "The CIDR range for the entire VPC."

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${CI}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+        "Usage: $(basename "$0")
+Ensure the Terraform source code is properly formatted.
+"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    if [[ "${1:-}" == "--help" ]]; then
+        usage
+    else
+        terraform fmt -check .
+        terraform fmt -check ./examples/terraform/
+    fi
+fi

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,69 @@
+variable "name" {
+  type        = string
+  default     = "Default"
+  description = "A name for the VPC."
+}
+
+variable "region" {
+  type        = string
+  description = "A valid AWS region to house VPC resources."
+}
+
+variable "cidr_block" {
+  type        = string
+  default     = "10.0.0.0/16"
+  description = "The CIDR range for the entire VPC."
+}
+
+variable "public_subnet_cidr_blocks" {
+  type        = list(string)
+  default     = ["10.0.0.0/24", "10.0.2.0/24"]
+  description = "A list of CIDR ranges for public subnets."
+}
+
+variable "public_subnet_ipv6_prefix_indices" {
+  type        = list(number)
+  default     = [0, 2]
+  description = "A list of indices corresponding to IPv6 prefixes for public subnets."
+}
+
+variable "private_subnet_cidr_blocks" {
+  type        = list(string)
+  default     = ["10.0.1.0/24", "10.0.3.0/24"]
+  description = "A list of CIDR ranges for private subnets."
+}
+
+variable "private_subnet_ipv6_prefix_indices" {
+  type        = list(number)
+  default     = [1, 3]
+  description = "A list of indices corresponding to IPv6 prefixes for private subnets."
+}
+
+variable "availability_zones" {
+  type        = list(string)
+  default     = ["us-east-1a", "us-east-1b"]
+  description = "A list of availability zones for subnet placement."
+}
+
+variable "bastion_ami" {
+  type        = string
+  description = "An AMI ID for the bastion."
+}
+
+variable "bastion_instance_type" {
+  type        = string
+  default     = "t3.nano"
+  description = "An instance type for the bastion."
+}
+
+variable "aws_ssm_managed_instance_core_policy_arn" {
+  type        = string
+  default     = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+  description = "ARN to the canned AmazonSSMManagedInstanceCore policy."
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "A mapping of keys and values to apply as tags to all resources that support them."
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.1.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.2.0"
+    }
+  }
+}


### PR DESCRIPTION
## Overview

The Terraform documentation describes a flat style of module usage which they call [module composition](https://www.terraform.io/language/modules/develop/composition#module-composition). With module composition, one takes multiple building-block modules and assembles them together to produce a larger system.

This repository forms the base of our first composable module. We're using Terraform to create a VPC with support for:

- Public and private subnets.
- Public and private route tables.
- Elastic IPs.
- Network interfaces.
- NAT gateways.
- An internet gateway and an egress-only internet gateway (for private IPv6 traffic).
- An S3 VPC endpoint.
- VPC endpoints to support AWS Session Manager.
- A bastion EC2 instance.

I based this module on my previous experiences working in production, the official [terraform-aws-vpc](https://github.com/terraform-aws-modules/terraform-aws-vpc) module, and Amazon's [Security best practices for your VPC](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-security-best-practices.html).

Resolves https://d3b.atlassian.net/browse/DEVOPS-511

## Testing Instructions
1. First, we need to configure the AWS CLI to authenticate with AWS SSO:

    <details>

    ```console
    $ aws configure sso --profile sandbox
    SSO start URL [None]: https://d-906762f877.awsapps.com/start
    SSO Region [None]: us-east-1
    Attempting to automatically open the SSO authorization page in your default browser.
    If the browser does not open or you wish to use a different device to authorize this request, open the following URL:

    https://device.sso.us-east-1.amazonaws.com/

    Then enter the code:

    JFSM-PBDB
    ```

    </details>

2. After authorizing the request in your browser, select the "sandbox" account:

    <details>

    ```console
    There are 2 AWS accounts available to you.
    aws-research-26060-chopd3bhippa01-prod, aws-research-26060-chopd3bhippa01-prod-admins@chop.edu (515011955314)
    > aws-research-7225140000-d3b-sandbox01-dev, aws-research-7225140000-d3b-sandbox01-dev-admins@chop.edu (452734729332)
    ```

    </details>

3. Finally, specify `us-east-1` as the default region when invoking `aws`:

    <details>

    ```console
    Using the account ID 452734729332
    The only role available to you is: AWSAdministratorAccess
    Using the role name "AWSAdministratorAccess"
    CLI default client Region [None]: us-east-1
    CLI default output format [None]:

    To use this profile, specify the profile name using --profile, as shown:

    aws s3 ls --profile sandbox
    ```

    </details>

4. Now that we've authenticated with AWS SSO, follow the instructions in the example project's [README](https://github.com/d3b-center/terraform-aws-vpc/tree/feature/jrb/bootstrap/examples) to stand up your own instance of the VPC. Please keep in mind that these instructions are meant to be consumed by the open-source community.

5. After standing up the VPC, use AWS SSM to open a shell on the bastion:

    <details>

    ```console
    bash-5.1# aws ssm start-session --target i-099e401ef15696b94

    Starting session with SessionId: BRESLOWJ@CHOP.EDU-05239866b48a68bfe
    cd ~ && /usr/bin/env bash
    sh-4.2$ cd ~ && /usr/bin/env bash
    [ssm-user@i-099e401ef15696b94 ~]$
    ```

    </details>

6. Modify the `sgBastion${your_generated_prefix}` security group in the AWS console to temporarily allow egress for all traffic on IPv4 and IPv6, so that we can run `traceroute`:

    <details>

    <img width="1785" alt="image" src="https://user-images.githubusercontent.com/1774125/156646259-ab6040ff-7e56-42a7-a43f-a0e069b94217.png">

    </details>

7. Now, verify that IPv4 traffic routes through the private IP address of the NAT gateway:

    <details>

    ```console
    [ssm-user@i-099e401ef15696b94 ~]$ sudo traceroute -4 --tcp google.com
    traceroute to google.com (142.250.188.46), 30 hops max, 60 byte packets
    1  ip-10-0-0-139.ec2.internal (10.0.0.139)  0.105 ms  0.227 ms  0.089 ms
    2  * * *
    3  * 243.254.31.78 (243.254.31.78)  0.794 ms 243.254.20.78 (243.254.20.78)  0.885 ms
    4  243.254.20.9 (243.254.20.9)  0.957 ms 243.254.18.129 (243.254.18.129)  0.776 ms *
    5  * * 240.0.232.23 (240.0.232.23)  0.742 ms
    6  243.253.17.118 (243.253.17.118)  1.010 ms 240.0.28.23 (240.0.28.23)  1.257 ms 243.253.18.126 (243.253.18.126)  1.082 ms
    7  * * 240.0.28.23 (240.0.28.23)  1.088 ms
    8  52.93.28.233 (52.93.28.233)  1.285 ms 52.93.28.255 (52.93.28.255)  1.264 ms 242.0.146.161 (242.0.146.161)  1.055 ms
    9  100.100.36.36 (100.100.36.36)  1.229 ms  1.036 ms 52.93.28.221 (52.93.28.221)  1.888 ms
    10  100.100.28.58 (100.100.28.58)  0.994 ms 100.100.28.96 (100.100.28.96)  1.213 ms 100.100.28.94 (100.100.28.94)  10.857 ms
    11  100.100.36.44 (100.100.36.44)  1.069 ms 99.83.113.89 (99.83.113.89)  3.192 ms 209.85.250.245 (209.85.250.245)  2.738 ms
    12  100.100.36.38 (100.100.36.38)  1.013 ms 142.251.69.209 (142.251.69.209)  1.033 ms 243.254.6.5 (243.254.6.5)  1.153 ms
    13  142.251.69.209 (142.251.69.209)  1.244 ms 142.251.69.211 (142.251.69.211)  1.276 ms 99.83.113.89 (99.83.113.89)  3.557 ms
    14  209.85.251.117 (209.85.251.117)  1.067 ms  1.206 ms iad30s46-in-f14.1e100.net (142.250.188.46)  1.370 ms
    ```

    _In this example TCP traceroute, the first hop is the private IP address of the NAT gateway, and the second hop is most likely the internet gateway._

    </details>

8. IPv6 traffic should go straight to the egress-only internet gateway:

    <details>

    ```console
    [ssm-user@i-099e401ef15696b94 ~]$ sudo traceroute -6 --tcp google.com
    traceroute to google.com (2607:f8b0:4004:832::200e), 30 hops max, 80 byte packets
    1  * * *
    2  * 2620:107:4000:c5c3::f3fd:63 (2620:107:4000:c5c3::f3fd:63)  0.522 ms 2620:107:4000:c5c3::f3fd:61 (2620:107:4000:c5c3::f3fd:61)  0.406 ms
    3  * 2620:107:4000:c5c3::f3fd:7d (2620:107:4000:c5c3::f3fd:7d)  0.359 ms 2620:107:4000:c5c2::f3fd:56 (2620:107:4000:c5c2::f3fd:56)  0.345 ms
    4  * 2620:107:4000:cfff::f3ff:1c19 (2620:107:4000:cfff::f3ff:1c19)  0.571 ms *
    5  * 2620:107:4000:c5e0::f3fd:c0e (2620:107:4000:c5e0::f3fd:c0e)  0.537 ms 2620:107:4000:c5e0::f3fd:c0c (2620:107:4000:c5e0::f3fd:c0c)  0.534 ms
    6  2620:107:4000:cfff::f200:b2b1 (2620:107:4000:cfff::f200:b2b1)  12.732 ms * 2620:107:4000:a6d0::f000:2c12 (2620:107:4000:a6d0::f000:2c12)  0.499 ms
    7  2620:107:4000:cfff::f200:9231 (2620:107:4000:cfff::f200:9231)  0.287 ms 2620:107:4000:2000::115 (2620:107:4000:2000::115)  0.321 ms 2620:107:4000:cfff::f200:93b1 (2620:107:4000:cfff::f200:93b1)  0.327 ms
    8  * 2620:107:4000:2000::f3 (2620:107:4000:2000::f3)  32.092 ms *
    9  2620:107:4000:8002::224 (2620:107:4000:8002::224)  0.392 ms * 2001:4860:1:1::1dda (2001:4860:1:1::1dda)  1.199 ms
    10  2620:107:4008:877::2 (2620:107:4008:877::2)  0.648 ms 2001:4860:0:1099::1 (2001:4860:0:1099::1)  0.993 ms 2001:4860:1:1::1dda (2001:4860:1:1::1dda)  1.080 ms
    11  2001:4860:0:1::1b53 (2001:4860:0:1::1b53)  0.833 ms 2620:107:4000:a650::f000:1c10 (2620:107:4000:a650::f000:1c10)  0.641 ms 2001:4860:0:1099::1 (2001:4860:0:1099::1)  0.961 ms
    12  2001:4860:0:1::534f (2001:4860:0:1::534f)  0.830 ms iad23s91-in-x0e.1e100.net (2607:f8b0:4004:832::200e)  0.749 ms 2620:107:4000:cfff::f200:92b1 (2620:107:4000:cfff::f200:92b1)  0.267 ms
    ```

    </details>

🎉

We've authenticated with AWS SSO, stood up our own VPC from scratch, and connected to a bastion instance that is inaccessible to the public internet.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202130333748249