### PR TITLE
Feature/nk/isdevops 561 gateway endpoints no bastion

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 A Terraform module to create a dual-stack (IPv4/IPv6) Amazon Web Services (AWS) Virtual Private Cloud (VPC).
 
 - [Usage](#usage)
-  - [Connecting to the Bastion with Session Manager](#connecting-to-the-bastion-with-aws-session-manager)
-  - [Configuring Security Group Rules](#configuring-security-group-rules)
 - [Variables](#variables)
 - [Outputs](#outputs)
 
@@ -20,21 +18,10 @@ This module creates a VPC alongside a variety of related resources, including:
 - An internet gateway and an egress-only internet gateway (for private IPv6 traffic).
 - An S3 VPC endpoint.
 - VPC endpoints to support AWS Session Manager.
-- A bastion EC2 instance.
 
 Example usage:
 
 ```hcl
-data "aws_ami" "amazon_linux" {
-  most_recent = true
-  owners      = ["amazon"]
-
-  filter {
-    name   = "name"
-    values = ["amzn2-ami-hvm*"]
-  }
-}
-
 module "vpc" {}
   source = "github.com/d3b-center/terraform-aws-vpc"
 
@@ -46,8 +33,6 @@ module "vpc" {}
   public_subnet_cidr_blocks          = ["10.0.0.0/24", "10.0.2.0/24"]
   public_subnet_ipv6_prefix_indices  = [0, 2]
   availability_zones                 = ["us-east-1a", "us-east-1b"]
-  bastion_ami                        = data.aws_ami.amazon_linux.id
-  bastion_instance_type              = "t3.nano"
 
   tags = {}
 }
@@ -68,24 +53,6 @@ sh-4.2$
 
 For information about accessing other VPC resources, see [How can I use an SSH tunnel through AWS Systems Manager to access my private VPC resources?](https://aws.amazon.com/premiumsupport/knowledge-center/systems-manager-ssh-vpc-resources/)
 
-### Configuring Security Group Rules
-
-Aside from those needed to support Session Manager, this module adds no security group rules to the bastion instance, meaning that all traffic will be blocked.
-
-In order to configure security rules for the bastion, use the `bastion_security_group_id` output. For example:
-
-```hcl
-resource "aws_security_group_rule" "bastion_https_egress" {
-  type             = "egress"
-  from_port        = 443
-  to_port          = 443
-  protocol         = "tcp"
-  cidr_blocks      = ["0.0.0.0/0"]
-  ipv6_cidr_blocks = ["::/0"]
-
-  security_group_id = module.vpc.bastion_security_group_id
-}
-```
 
 ## Variables
 
@@ -97,9 +64,6 @@ resource "aws_security_group_rule" "bastion_https_egress" {
 - `private_subnet_cidr_blocks` - A list of CIDR ranges for private subnets (default: `["10.0.1.0/24", "10.0.3.0/24"]`).
 - `private_subnet_ipv6_prefix_indices` - A list of indices corresponding to IPv6 prefixes for public subnets (default: `[1, 3]`).
 - `availability_zones` - A list of availability zones for subnet placement (default: `["us-east-1a", "us-east-1b"]`).
-- `bastion_ami` - An AMI ID for the bastion.
-- `bastion_instance_type` - An instance type for the bastion (default: `t3.nano`).
-- `aws_ssm_managed_instance_core_policy_arn` - ARN to the canned AmazonSSMManagedInstanceCore policy. (default: `arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore`).
 - `tags` - A mapping of keys and values to apply as tags to all resources that support them (default: `{}`).
 
 ## Outputs
@@ -107,9 +71,6 @@ resource "aws_security_group_rule" "bastion_https_egress" {
 - `id` - ID of the VPC.
 - `public_subnet_ids` - A list of VPC public subnet IDs.
 - `private_subnets_ids` - A list of VPC private subnet IDs.
-- `vpc_endpoint_security_group_id` - Security group associated with the interface VPC endpoints for adding rules.
-- `bastion_security_group_id` - Security group associated with the bastion for adding rules.
-- `bastion_iam_role_name` - IAM role associated with the bastion for attaching IAM policies.
 - `cidr_block` - The CIDR range for the entire VPC.
 - `ipv6_cidr_block` - The IPv6 CIDR range for the entire VPC.
 - `nat_gateway_ips` - Public IP addresses of the VPC NAT gateways.

--- a/main.tf
+++ b/main.tf
@@ -186,8 +186,8 @@ resource "aws_security_group_rule" "vpc_endpoint_ingress" {
   to_port   = 443
   protocol  = "tcp"
 
-  security_group_id        = aws_security_group.vpc_endpoint.id
-  cidr_blocks = [var.cidr_block]
+  security_group_id = aws_security_group.vpc_endpoint.id
+  cidr_blocks       = [var.cidr_block]
 
   description = "Allow inbound TCP traffic from the VPC on 443."
 }

--- a/main.tf
+++ b/main.tf
@@ -180,10 +180,6 @@ resource "aws_security_group" "vpc_endpoint" {
   )
 }
 
-data "aws_vpc" "vpc_data" {
-  id = aws_vpc.default.id
-}
-
 resource "aws_security_group_rule" "vpc_endpoint_ingress" {
   type      = "ingress"
   from_port = 443
@@ -191,7 +187,7 @@ resource "aws_security_group_rule" "vpc_endpoint_ingress" {
   protocol  = "tcp"
 
   security_group_id        = aws_security_group.vpc_endpoint.id
-  cidr_blocks = [data.aws_vpc.vpc_data.cidr_block]
+  cidr_blocks = [var.cidr_block]
 
   description = "Allow inbound TCP traffic from the VPC on 443."
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,21 +13,6 @@ output "private_subnet_ids" {
   description = "A list of VPC private subnet IDs."
 }
 
-output "vpc_endpoint_security_group_id" {
-  value       = aws_security_group.vpc_endpoint.id
-  description = "Security group associated with the interface VPC endpoints for adding rules."
-}
-
-output "bastion_security_group_id" {
-  value       = aws_security_group.bastion.id
-  description = "Security group associated with the bastion for adding rules."
-}
-
-output "bastion_iam_role_name" {
-  value       = aws_iam_role.bastion.name
-  description = "IAM role associated with the bastion for attaching IAM policies."
-}
-
 output "cidr_block" {
   value       = var.cidr_block
   description = "The CIDR range for the entire VPC."

--- a/variables.tf
+++ b/variables.tf
@@ -45,23 +45,6 @@ variable "availability_zones" {
   description = "A list of availability zones for subnet placement."
 }
 
-variable "bastion_ami" {
-  type        = string
-  description = "An AMI ID for the bastion."
-}
-
-variable "bastion_instance_type" {
-  type        = string
-  default     = "t3.nano"
-  description = "An instance type for the bastion."
-}
-
-variable "aws_ssm_managed_instance_core_policy_arn" {
-  type        = string
-  default     = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
-  description = "ARN to the canned AmazonSSMManagedInstanceCore policy."
-}
-
 variable "tags" {
   type        = map(string)
   default     = {}


### PR DESCRIPTION
Turns out you can't use gateway VPC endpoints for a lot of AWS services, but this gets rid of the weird firewalling that only allowed the bastion SG to access SSM endpoints. Now all instances in the VPC should be able to access SSM endpoints.

Also removed the bastion host and related resources and made everything take the VPC name as a prefix.