### PR TITLE
Add vpce for different services

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -255,7 +255,7 @@ resource "aws_vpc_endpoint" "secretsmanager" {
 
 resource "aws_vpc_endpoint" "cloudwatch" {
   vpc_id            = aws_vpc.default.id
-  service_name      = "com.amazonaws.${var.region}.cloudwatch"
+  service_name      = "com.amazonaws.${var.region}.monitoring"
   vpc_endpoint_type = "Interface"
 
   security_group_ids = [

--- a/main.tf
+++ b/main.tf
@@ -236,14 +236,11 @@ resource "aws_vpc_endpoint" "ssm" {
 resource "aws_vpc_endpoint" "secretsmanager" {
   vpc_id            = aws_vpc.default.id
   service_name      = "com.amazonaws.${var.region}.secretsmanager"
-  vpc_endpoint_type = "Interface"
 
-  security_group_ids = [
-    aws_security_group.vpc_endpoint.id
-  ]
-
-  subnet_ids          = aws_subnet.private.*.id
-  private_dns_enabled = true
+  route_table_ids = flatten([
+    aws_route_table.public.id,
+    aws_route_table.private.*.id
+  ])
 
   tags = merge(
     {

--- a/main.tf
+++ b/main.tf
@@ -253,6 +253,26 @@ resource "aws_vpc_endpoint" "secretsmanager" {
   )
 }
 
+resource "aws_vpc_endpoint" "cloudwatch" {
+  vpc_id            = aws_vpc.default.id
+  service_name      = "com.amazonaws.${var.region}.cloudwatch"
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids = [
+    aws_security_group.vpc_endpoint.id
+  ]
+
+  subnet_ids          = aws_subnet.private.*.id
+  private_dns_enabled = true
+
+  tags = merge(
+    {
+      Name = "${var.name}-endpointCloudWatch"
+    },
+    var.tags
+  )
+}
+
 resource "aws_vpc_endpoint" "ecr_api" {
   vpc_id            = aws_vpc.default.id
   service_name      = "com.amazonaws.${var.region}.ecr.api"

--- a/main.tf
+++ b/main.tf
@@ -247,7 +247,7 @@ resource "aws_vpc_endpoint" "secretsmanager" {
 
   tags = merge(
     {
-      Name = "${var.name}-endpointSsm"
+      Name = "${var.name}-endpointSecretsManager"
     },
     var.tags
   )

--- a/main.tf
+++ b/main.tf
@@ -233,7 +233,7 @@ resource "aws_vpc_endpoint" "ssm" {
   )
 }
 
-resource "aws_vpc_endpoint" "ssm" {
+resource "aws_vpc_endpoint" "secretsmanager" {
   vpc_id            = aws_vpc.default.id
   service_name      = "com.amazonaws.${var.region}.secretsmanager"
   vpc_endpoint_type = "Interface"

--- a/main.tf
+++ b/main.tf
@@ -253,27 +253,6 @@ resource "aws_vpc_endpoint" "secretsmanager" {
   )
 }
 
-resource "aws_vpc_endpoint" "ecr" {
-  vpc_id            = aws_vpc.default.id
-  service_name      = "com.amazonaws.${var.region}.ecr"
-  vpc_endpoint_type = "Interface"
-
-  security_group_ids = [
-    aws_security_group.vpc_endpoint.id
-  ]
-
-  subnet_ids          = aws_subnet.private.*.id
-  private_dns_enabled = true
-
-  tags = merge(
-    {
-      Name = "${var.name}-endpointECR"
-    },
-    var.tags
-  )
-}
-
-
 resource "aws_vpc_endpoint" "ssmmessages" {
   vpc_id            = aws_vpc.default.id
   service_name      = "com.amazonaws.${var.region}.ssmmessages"

--- a/main.tf
+++ b/main.tf
@@ -236,11 +236,14 @@ resource "aws_vpc_endpoint" "ssm" {
 resource "aws_vpc_endpoint" "secretsmanager" {
   vpc_id            = aws_vpc.default.id
   service_name      = "com.amazonaws.${var.region}.secretsmanager"
+  vpc_endpoint_type = "Interface"
 
-  route_table_ids = flatten([
-    aws_route_table.public.id,
-    aws_route_table.private.*.id
-  ])
+  security_group_ids = [
+    aws_security_group.vpc_endpoint.id
+  ]
+
+  subnet_ids          = aws_subnet.private.*.id
+  private_dns_enabled = true
 
   tags = merge(
     {

--- a/main.tf
+++ b/main.tf
@@ -250,6 +250,47 @@ resource "aws_vpc_endpoint" "secretsmanager" {
   )
 }
 
+resource "aws_vpc_endpoint" "ecr_api" {
+  vpc_id            = aws_vpc.default.id
+  service_name      = "com.amazonaws.${var.region}.ecr.api"
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids = [
+    aws_security_group.vpc_endpoint.id
+  ]
+
+  subnet_ids          = aws_subnet.private.*.id
+  private_dns_enabled = true
+
+  tags = merge(
+    {
+      Name = "${var.name}-endpointECR_API"
+    },
+    var.tags
+  )
+}
+
+
+resource "aws_vpc_endpoint" "ecr_dkr" {
+  vpc_id            = aws_vpc.default.id
+  service_name      = "com.amazonaws.${var.region}.ecr.dkr"
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids = [
+    aws_security_group.vpc_endpoint.id
+  ]
+
+  subnet_ids          = aws_subnet.private.*.id
+  private_dns_enabled = true
+
+  tags = merge(
+    {
+      Name = "${var.name}-endpointECR_DKR"
+    },
+    var.tags
+  )
+}
+
 resource "aws_vpc_endpoint" "ssmmessages" {
   vpc_id            = aws_vpc.default.id
   service_name      = "com.amazonaws.${var.region}.ssmmessages"

--- a/main.tf
+++ b/main.tf
@@ -253,6 +253,27 @@ resource "aws_vpc_endpoint" "secretsmanager" {
   )
 }
 
+resource "aws_vpc_endpoint" "ecr" {
+  vpc_id            = aws_vpc.default.id
+  service_name      = "com.amazonaws.${var.region}.ecr"
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids = [
+    aws_security_group.vpc_endpoint.id
+  ]
+
+  subnet_ids          = aws_subnet.private.*.id
+  private_dns_enabled = true
+
+  tags = merge(
+    {
+      Name = "${var.name}-endpointECR"
+    },
+    var.tags
+  )
+}
+
+
 resource "aws_vpc_endpoint" "ssmmessages" {
   vpc_id            = aws_vpc.default.id
   service_name      = "com.amazonaws.${var.region}.ssmmessages"

--- a/main.tf
+++ b/main.tf
@@ -233,6 +233,26 @@ resource "aws_vpc_endpoint" "ssm" {
   )
 }
 
+resource "aws_vpc_endpoint" "ssm" {
+  vpc_id            = aws_vpc.default.id
+  service_name      = "com.amazonaws.${var.region}.secretsmanager"
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids = [
+    aws_security_group.vpc_endpoint.id
+  ]
+
+  subnet_ids          = aws_subnet.private.*.id
+  private_dns_enabled = true
+
+  tags = merge(
+    {
+      Name = "${var.name}-endpointSsm"
+    },
+    var.tags
+  )
+}
+
 resource "aws_vpc_endpoint" "ssmmessages" {
   vpc_id            = aws_vpc.default.id
   service_name      = "com.amazonaws.${var.region}.ssmmessages"

--- a/outputs.tf
+++ b/outputs.tf
@@ -27,11 +27,3 @@ output "nat_gateway_ips" {
   value       = [aws_eip.nat.*.public_ip]
   description = "Public IP addresses of the VPC NAT gateways."
 }
-
-output "route_table_public" {
-    value = [aws_route_table.public.id]
-}
-
-output "route_table_private" {
-    value = [aws_route_table.private.*.id]
-}

--- a/outputs.tf
+++ b/outputs.tf
@@ -27,3 +27,11 @@ output "nat_gateway_ips" {
   value       = [aws_eip.nat.*.public_ip]
   description = "Public IP addresses of the VPC NAT gateways."
 }
+
+output "route_table_public" {
+    value = [aws_route_table.public.id]
+}
+
+output "route_table_private" {
+    value = [aws_route_table.private.*.id]
+}


### PR DESCRIPTION
Description
===========

https://d3b.atlassian.net/jira/software/c/projects/AD/boards/138?assignee=5b27c502835f7165ffe2f22e&selectedIssue=AD-884

Created several services within VPC that is required for any VPC that is deployed on CHOP account.

- **:lock: Added route table to output, to allow to create VPCE**
- **:tada: Added SecretsManager VPC Endpoint**
- **:pencil: Fixed typo in the resource name**
- **:pencil: Updated tag**
- **:tada: Added ECR endpoint as well**
- **:x: Removed ECR**
- **:wrench: Updated secrets manager endpoint**
- **:wrench: Added ECR DKR and API**
- **:wrench: Service type Gateway is not available for SecretsManager vpc endpoint**
- **:wrench: Added CloudWatch Endpoint**
- **:wrench: Updated the name for the endpoint**
