### PR TITLE
:wrench: Changed deprecated attribute to domain = vpc

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -256,7 +256,6 @@ resource "aws_vpc_endpoint" "secretsmanager" {
 resource "aws_vpc_endpoint" "cloudwatch" {
   vpc_id            = aws_vpc.default.id
   service_name      = "com.amazonaws.${var.region}.monitoring"
-  vpc_endpoint_type = "Interface"
 
   security_group_ids = [
     aws_security_group.vpc_endpoint.id

--- a/main.tf
+++ b/main.tf
@@ -256,6 +256,7 @@ resource "aws_vpc_endpoint" "secretsmanager" {
 resource "aws_vpc_endpoint" "cloudwatch" {
   vpc_id            = aws_vpc.default.id
   service_name      = "com.amazonaws.${var.region}.monitoring"
+  vpc_endpoint_type = "Interface"
 
   security_group_ids = [
     aws_security_group.vpc_endpoint.id
@@ -275,6 +276,7 @@ resource "aws_vpc_endpoint" "cloudwatch" {
 resource "aws_vpc_endpoint" "cw_logs" {
   vpc_id            = aws_vpc.default.id
   service_name      = "com.amazonaws.${var.region}.logs"
+  vpc_endpoint_type = "Interface"
 
   security_group_ids = [
     aws_security_group.vpc_endpoint.id

--- a/main.tf
+++ b/main.tf
@@ -272,6 +272,26 @@ resource "aws_vpc_endpoint" "cloudwatch" {
   )
 }
 
+resource "aws_vpc_endpoint" "cw_logs" {
+  vpc_id            = aws_vpc.default.id
+  service_name      = "com.amazonaws.${var.region}.logs"
+
+  security_group_ids = [
+    aws_security_group.vpc_endpoint.id
+  ]
+
+  subnet_ids          = aws_subnet.private.*.id
+  private_dns_enabled = true
+
+  tags = merge(
+    {
+      Name = "${var.name}-endpointCloudWatchLogs"
+    },
+    var.tags
+  )
+}
+
+
 resource "aws_vpc_endpoint" "ecr_api" {
   vpc_id            = aws_vpc.default.id
   service_name      = "com.amazonaws.${var.region}.ecr.api"

--- a/main.tf
+++ b/main.tf
@@ -340,7 +340,7 @@ resource "aws_vpc_endpoint" "ssmmessages" {
 resource "aws_eip" "nat" {
   count = length(var.public_subnet_cidr_blocks)
 
-  vpc = true
+  domain = "vpc"
 
   tags = merge(
     {


### PR DESCRIPTION
Description
===========

Replaced deprecated attribute with domain="vpc". This change is required for 5.0 version upgrade of AWS provider.
https://github.com/terraform-aws-modules/terraform-aws-vpc/pull/941

- Added Logs endpoint.
