### PR TITLE
add flag for ipv6

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -21,6 +21,12 @@ variable "public_subnet_cidr_blocks" {
   description = "A list of CIDR ranges for public subnets."
 }
 
+variable "ipv6_enabled" {
+  type = bool
+  default = true
+  description = "value"
+}
+
 variable "public_subnet_ipv6_prefix_indices" {
   type        = list(number)
   default     = [0, 2]


### PR DESCRIPTION
Need to disable IpV6 for Dewrangle environments (and probably future accounts). VPC Endpoints does not currently support IPv6, so it causes intermittent connection timeouts.